### PR TITLE
Add advanced card metadata and acceptance/test criteria

### DIFF
--- a/ajax/card.php
+++ b/ajax/card.php
@@ -80,8 +80,22 @@ function createCard() {
         'assignee' => $_POST['assignee'] ?? '',
         'reporter' => $_POST['reporter'] ?? $_SESSION['glpiname'],
         'due_date' => $_POST['due_date'] ?: null,
-        'tickets_id' => intval($_POST['tickets_id'] ?? 0)
+        'planned_due_date' => $_POST['planned_due_date'] ?: null,
+        'done_date' => $_POST['done_date'] ?: null,
+        'tickets_id' => intval($_POST['tickets_id'] ?? 0),
+        'branch' => trim($_POST['branch'] ?? ''),
+        'pull_request' => trim($_POST['pull_request'] ?? ''),
+        'dor_percent' => intval($_POST['dor_percent'] ?? 0),
+        'dod_percent' => intval($_POST['dod_percent'] ?? 0)
     ];
+
+    if (($criteria = getCollectionFromRequest($_POST, 'acceptance_criteria')) !== null) {
+        $input['acceptance_criteria'] = $criteria;
+    }
+
+    if (($scenarios = getCollectionFromRequest($_POST, 'test_scenarios')) !== null) {
+        $input['test_scenarios'] = $scenarios;
+    }
     
     if ($card->add($input)) {
         $card_id = $card->getID();
@@ -140,7 +154,7 @@ function moveCard() {
 function getCardDetails() {
     $card = new PluginScrumbanCard();
     $card_id = intval($_GET['card_id']);
-    
+
     if (!$card->getFromDB($card_id)) {
         return [
             'success' => false,
@@ -151,14 +165,18 @@ function getCardDetails() {
     // Buscar informações adicionais
     $labels = $card->getLabels();
     $activity = $card->getActivityHistory();
-    
+    $acceptance = PluginScrumbanCard::getAcceptanceCriteriaForCard($card_id);
+    $test_scenarios = PluginScrumbanCard::getTestScenariosForCard($card_id);
+
     // Gerar HTML dos detalhes
-    $html = generateCardDetailsHtml($card, $labels, $activity);
-    
+    $html = generateCardDetailsHtml($card, $labels, $activity, $acceptance, $test_scenarios);
+
     return [
         'success' => true,
         'html' => $html,
-        'card' => $card->exportData()
+        'card' => $card->exportData(),
+        'acceptance_criteria' => $acceptance,
+        'test_scenarios' => $test_scenarios
     ];
 }
 
@@ -177,6 +195,12 @@ function updateCard() {
     }
     
     $input = $_POST;
+    if (($criteria = getCollectionFromRequest($_POST, 'acceptance_criteria')) !== null) {
+        $input['acceptance_criteria'] = $criteria;
+    }
+    if (($scenarios = getCollectionFromRequest($_POST, 'test_scenarios')) !== null) {
+        $input['test_scenarios'] = $scenarios;
+    }
     $input['id'] = $card_id;
     
     if ($card->update($input)) {
@@ -198,7 +222,7 @@ function updateCard() {
 function deleteCard() {
     $card = new PluginScrumbanCard();
     $card_id = intval($_POST['card_id']);
-    
+
     if ($card->getFromDB($card_id)) {
         if ($card->delete(['id' => $card_id])) {
             return [
@@ -214,10 +238,28 @@ function deleteCard() {
     ];
 }
 
+function getCollectionFromRequest($source, $key) {
+    if (!isset($source[$key])) {
+        return null;
+    }
+
+    $value = $source[$key];
+    if (is_string($value)) {
+        $decoded = json_decode($value, true);
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    if (is_array($value)) {
+        return $value;
+    }
+
+    return [];
+}
+
 /**
  * Gerar HTML dos detalhes do card
  */
-function generateCardDetailsHtml($card, $labels, $activity) {
+function generateCardDetailsHtml($card, $labels, $activity, $acceptance = [], $test_scenarios = []) {
     $priority_labels = [
         'trivial' => __('Trivial', 'scrumban'),
         'menor' => __('Menor', 'scrumban'),
@@ -225,30 +267,83 @@ function generateCardDetailsHtml($card, $labels, $activity) {
         'maior' => __('Maior', 'scrumban'),
         'critico' => __('Crítico', 'scrumban')
     ];
-    
+
     $type_labels = [
         'story' => __('História', 'scrumban'),
         'task' => __('Tarefa', 'scrumban'),
         'bug' => __('Bug', 'scrumban'),
         'epic' => __('Épico', 'scrumban')
     ];
-    
+
+    $acceptance_labels = PluginScrumbanCard::getAcceptanceStatusOptions();
+    $test_labels = PluginScrumbanCard::getTestScenarioStatusOptions();
+
+    $acceptance_status_classes = [
+        'pending' => 'secondary',
+        'in_progress' => 'info',
+        'done' => 'success'
+    ];
+
+    $test_status_classes = [
+        'not_run' => 'secondary',
+        'in_progress' => 'info',
+        'passed' => 'success',
+        'failed' => 'danger',
+        'blocked' => 'warning'
+    ];
+
+    $acceptance_total = count($acceptance);
+    $acceptance_done = 0;
+    foreach ($acceptance as $criterion) {
+        if ($criterion['status'] === 'done') {
+            $acceptance_done++;
+        }
+    }
+    $acceptance_progress = $acceptance_total > 0 ? (int)round(($acceptance_done / $acceptance_total) * 100) : 0;
+
+    $test_counts = [];
+    foreach ($test_labels as $key => $label) {
+        $test_counts[$key] = 0;
+    }
+    foreach ($test_scenarios as $scenario) {
+        $status = $scenario['status'];
+        if (!isset($test_counts[$status])) {
+            $test_counts[$status] = 0;
+        }
+        $test_counts[$status]++;
+    }
+    $test_total = count($test_scenarios);
+
+    $branch_display = !empty($card->fields['branch']) ? htmlspecialchars($card->fields['branch'], ENT_QUOTES, 'UTF-8') : __('Não informado', 'scrumban');
+    $pull_request_display = __('Não informado', 'scrumban');
+    if (!empty($card->fields['pull_request'])) {
+        $pull = $card->fields['pull_request'];
+        if (filter_var($pull, FILTER_VALIDATE_URL)) {
+            $safe = htmlspecialchars($pull, ENT_QUOTES, 'UTF-8');
+            $pull_request_display = "<a href='" . $safe . "' target='_blank' rel='noopener'>" . $safe . "</a>";
+        } else {
+            $pull_request_display = htmlspecialchars($pull, ENT_QUOTES, 'UTF-8');
+        }
+    }
+
+    $dor_percent = intval($card->fields['dor_percent']);
+    $dod_percent = intval($card->fields['dod_percent']);
+
     ob_start();
     ?>
     <div class="row">
         <div class="col-md-8">
             <div class="mb-4">
                 <h4><?php echo htmlspecialchars($card->fields['title']); ?></h4>
-                <div class="d-flex gap-2 mb-3">
+                <div class="d-flex gap-2 mb-3 flex-wrap">
                     <span class="badge bg-secondary"><?php echo $type_labels[$card->fields['type']] ?? $card->fields['type']; ?></span>
-                    <span class="badge bg-info"><?php echo __('Backlog', 'scrumban'); ?></span>
-                    <span class="badge bg-warning"><?php echo $priority_labels[$card->fields['priority']] ?? $card->fields['priority']; ?></span>
+                    <span class="badge bg-warning text-dark"><?php echo $priority_labels[$card->fields['priority']] ?? $card->fields['priority']; ?></span>
                     <?php if ($card->fields['story_points'] > 0): ?>
                         <span class="badge bg-primary"><?php echo $card->fields['story_points']; ?> pts</span>
                     <?php endif; ?>
                 </div>
             </div>
-            
+
             <?php if (!empty($card->fields['description'])): ?>
             <div class="mb-4">
                 <h6><?php echo __('Descrição', 'scrumban'); ?></h6>
@@ -257,69 +352,164 @@ function generateCardDetailsHtml($card, $labels, $activity) {
                 </div>
             </div>
             <?php endif; ?>
-            
-            <div class="mb-4">
-                <h6><?php echo __('Critérios de Aceitação', 'scrumban'); ?></h6>
-                <div class="p-3 bg-warning bg-opacity-10 rounded">
-                    <ul class="mb-0">
-                        <li><?php echo __('Funcionalidade deve estar implementada', 'scrumban'); ?></li>
-                        <li><?php echo __('Testes unitários aprovados', 'scrumban'); ?></li>
-                        <li><?php echo __('Documentação atualizada', 'scrumban'); ?></li>
-                        <li><?php echo __('Code review realizado', 'scrumban'); ?></li>
-                    </ul>
+
+            <div class="card mb-4">
+                <div class="card-body">
+                    <h6 class="card-title"><?php echo __('Desenvolvimento', 'scrumban'); ?></h6>
+                    <div class="row g-3">
+                        <div class="col-sm-6">
+                            <strong><?php echo __('Branch', 'scrumban'); ?>:</strong><br>
+                            <span class="text-muted"><?php echo $branch_display; ?></span>
+                        </div>
+                        <div class="col-sm-6">
+                            <strong><?php echo __('Pull Request', 'scrumban'); ?>:</strong><br>
+                            <span class="text-muted"><?php echo $pull_request_display; ?></span>
+                        </div>
+                        <div class="col-sm-6">
+                            <strong><?php echo __('Planned Due Date', 'scrumban'); ?>:</strong><br>
+                            <span class="text-muted"><?php echo $card->fields['planned_due_date'] ? Html::convDate($card->fields['planned_due_date']) : __('Não definido', 'scrumban'); ?></span>
+                        </div>
+                        <div class="col-sm-6">
+                            <strong><?php echo __('Due Date', 'scrumban'); ?>:</strong><br>
+                            <span class="text-muted"><?php echo $card->fields['due_date'] ? Html::convDate($card->fields['due_date']) : __('Não definido', 'scrumban'); ?></span>
+                        </div>
+                        <div class="col-sm-6">
+                            <strong><?php echo __('Done Date', 'scrumban'); ?>:</strong><br>
+                            <span class="text-muted"><?php echo $card->fields['done_date'] ? Html::convDate($card->fields['done_date']) : __('Não definido', 'scrumban'); ?></span>
+                        </div>
+                    </div>
+                    <div class="row g-3 mt-2">
+                        <div class="col-sm-6">
+                            <strong><?php echo __('Definition of Ready', 'scrumban'); ?></strong>
+                            <div class="progress" role="progressbar" aria-valuenow="<?php echo $dor_percent; ?>" aria-valuemin="0" aria-valuemax="100">
+                                <div class="progress-bar bg-info" style="width: <?php echo $dor_percent; ?>%;"><?php echo $dor_percent; ?>%</div>
+                            </div>
+                        </div>
+                        <div class="col-sm-6">
+                            <strong><?php echo __('Definition of Done', 'scrumban'); ?></strong>
+                            <div class="progress" role="progressbar" aria-valuenow="<?php echo $dod_percent; ?>" aria-valuemin="0" aria-valuemax="100">
+                                <div class="progress-bar bg-success" style="width: <?php echo $dod_percent; ?>%;"><?php echo $dod_percent; ?>%</div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
-            
+
+            <div class="card mb-4">
+                <div class="card-body">
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <h6 class="card-title mb-0"><?php echo __('Critérios de Aceitação', 'scrumban'); ?></h6>
+                        <span class="badge bg-primary"><?php echo sprintf(__('%1$d de %2$d concluídos', 'scrumban'), $acceptance_done, $acceptance_total); ?></span>
+                    </div>
+                    <div class="progress mb-3" role="progressbar" aria-valuenow="<?php echo $acceptance_progress; ?>" aria-valuemin="0" aria-valuemax="100">
+                        <div class="progress-bar bg-success" style="width: <?php echo $acceptance_progress; ?>%;"><?php echo $acceptance_progress; ?>%</div>
+                    </div>
+                    <?php if (!empty($acceptance)): ?>
+                    <ul class="list-group list-group-flush">
+                        <?php foreach ($acceptance as $criterion): ?>
+                        <li class="list-group-item d-flex justify-content-between align-items-start">
+                            <div class="me-3">
+                                <?php echo nl2br(htmlspecialchars($criterion['description'])); ?>
+                            </div>
+                            <span class="badge bg-<?php echo $acceptance_status_classes[$criterion['status']] ?? 'secondary'; ?>"><?php echo $acceptance_labels[$criterion['status']] ?? $criterion['status']; ?></span>
+                        </li>
+                        <?php endforeach; ?>
+                    </ul>
+                    <?php else: ?>
+                    <p class="text-muted mb-0"><?php echo __('Nenhum critério de aceitação cadastrado.', 'scrumban'); ?></p>
+                    <?php endif; ?>
+                </div>
+            </div>
+
+            <div class="card mb-4">
+                <div class="card-body">
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <h6 class="card-title mb-0"><?php echo __('Cenários de Teste', 'scrumban'); ?></h6>
+                        <?php if ($test_total > 0): ?>
+                        <div class="d-flex gap-2 flex-wrap">
+                            <?php foreach ($test_labels as $key => $label): ?>
+                                <?php $count = $test_counts[$key] ?? 0; ?>
+                                <?php if ($count > 0): ?>
+                                    <span class="badge bg-<?php echo $test_status_classes[$key] ?? 'secondary'; ?>"><?php echo $label; ?>: <?php echo $count; ?></span>
+                                <?php endif; ?>
+                            <?php endforeach; ?>
+                        </div>
+                        <?php endif; ?>
+                    </div>
+                    <?php if (!empty($test_scenarios)): ?>
+                    <div class="table-responsive">
+                        <table class="table table-sm mb-0">
+                            <thead>
+                                <tr>
+                                    <th><?php echo __('Cenário', 'scrumban'); ?></th>
+                                    <th style="width: 160px;"><?php echo __('Status', 'scrumban'); ?></th>
+                                    <th><?php echo __('Notas', 'scrumban'); ?></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <?php foreach ($test_scenarios as $scenario): ?>
+                                <tr>
+                                    <td><?php echo htmlspecialchars($scenario['name']); ?></td>
+                                    <td><span class="badge bg-<?php echo $test_status_classes[$scenario['status']] ?? 'secondary'; ?>"><?php echo $test_labels[$scenario['status']] ?? $scenario['status']; ?></span></td>
+                                    <td><?php echo nl2br(htmlspecialchars($scenario['notes'])); ?></td>
+                                </tr>
+                                <?php endforeach; ?>
+                            </tbody>
+                        </table>
+                    </div>
+                    <?php else: ?>
+                    <p class="text-muted mb-0"><?php echo __('Nenhum cenário de teste registrado.', 'scrumban'); ?></p>
+                    <?php endif; ?>
+                </div>
+            </div>
+
             <?php if (!empty($labels)): ?>
-            <div>
-                <h6><?php echo __('Labels', 'scrumban'); ?></h6>
-                <div class="d-flex gap-2">
-                    <?php foreach ($labels as $label): ?>
-                        <span class="badge bg-primary" style="background-color: <?php echo $label['color']; ?> !important;">
-                            <?php echo htmlspecialchars($label['name']); ?>
-                        </span>
-                    <?php endforeach; ?>
+            <div class="card mb-4">
+                <div class="card-body">
+                    <h6 class="card-title"><?php echo __('Labels', 'scrumban'); ?></h6>
+                    <div class="d-flex gap-2 flex-wrap">
+                        <?php foreach ($labels as $label): ?>
+                            <span class="badge" style="background-color: <?php echo htmlspecialchars($label['color']); ?>; color: #fff;">
+                                <?php echo htmlspecialchars($label['name']); ?>
+                            </span>
+                        <?php endforeach; ?>
+                    </div>
                 </div>
             </div>
             <?php endif; ?>
         </div>
-        
+
         <div class="col-md-4">
-            <div class="card">
+            <div class="card mb-3">
                 <div class="card-body">
                     <h6 class="card-title"><?php echo __('Informações', 'scrumban'); ?></h6>
-                    
                     <div class="mb-3">
                         <strong><?php echo __('Responsável', 'scrumban'); ?>:</strong><br>
                         <span class="text-muted"><?php echo htmlspecialchars($card->fields['assignee'] ?: __('Não atribuído', 'scrumban')); ?></span>
                     </div>
-                    
                     <div class="mb-3">
                         <strong><?php echo __('Reporter', 'scrumban'); ?>:</strong><br>
                         <span class="text-muted"><?php echo htmlspecialchars($card->fields['reporter']); ?></span>
                     </div>
-                    
-                    <div class="mb-3">
-                        <strong><?php echo __('Criado em', 'scrumban'); ?>:</strong><br>
-                        <span class="text-muted"><?php echo Html::convDateTime($card->fields['date_creation']); ?></span>
-                    </div>
-                    
                     <div class="mb-3">
                         <strong><?php echo __('Story Points', 'scrumban'); ?>:</strong><br>
                         <span class="text-muted"><?php echo $card->fields['story_points'] ?: __('Não estimado', 'scrumban'); ?></span>
                     </div>
-                    
-                    <?php if ($card->fields['due_date']): ?>
                     <div class="mb-3">
-                        <strong><?php echo __('Data Limite', 'scrumban'); ?>:</strong><br>
-                        <span class="text-muted"><?php echo Html::convDate($card->fields['due_date']); ?></span>
+                        <strong><?php echo __('Criado em', 'scrumban'); ?>:</strong><br>
+                        <span class="text-muted"><?php echo Html::convDateTime($card->fields['date_creation']); ?></span>
+                    </div>
+                    <?php if ($card->fields['done_date']): ?>
+                    <div class="mb-3">
+                        <strong><?php echo __('Concluído em', 'scrumban'); ?>:</strong><br>
+                        <span class="text-muted"><?php echo Html::convDate($card->fields['done_date']); ?></span>
                     </div>
                     <?php endif; ?>
                 </div>
             </div>
-            
+
             <?php if (!empty($activity)): ?>
-            <div class="card mt-3">
+            <div class="card">
                 <div class="card-body">
                     <h6 class="card-title"><?php echo __('Atividade Recente', 'scrumban'); ?></h6>
                     <div class="timeline-sm">
@@ -341,4 +531,5 @@ function generateCardDetailsHtml($card, $labels, $activity) {
     <?php
     return ob_get_clean();
 }
+
 ?>

--- a/inc/card.class.php
+++ b/inc/card.class.php
@@ -6,6 +6,390 @@ if (!defined('GLPI_ROOT')) {
 
 class PluginScrumbanCard extends CommonDBTM {
 
+   private $pendingAcceptanceCriteria = null;
+   private $pendingTestScenarios = null;
+
+   const ACCEPTANCE_STATUSES = ['pending', 'in_progress', 'done'];
+   const TEST_SCENARIO_STATUSES = ['not_run', 'in_progress', 'passed', 'failed', 'blocked'];
+
+   static function getAcceptanceStatusOptions() {
+      return [
+         'pending' => __('Pendente', 'scrumban'),
+         'in_progress' => __('Em andamento', 'scrumban'),
+         'done' => __('Concluído', 'scrumban')
+      ];
+   }
+
+   static function getTestScenarioStatusOptions() {
+      return [
+         'not_run' => __('Não executado', 'scrumban'),
+         'in_progress' => __('Em execução', 'scrumban'),
+         'passed' => __('Aprovado', 'scrumban'),
+         'failed' => __('Reprovado', 'scrumban'),
+         'blocked' => __('Bloqueado', 'scrumban')
+      ];
+   }
+
+   private static function renderAcceptanceCriterionRow($index, $criterion) {
+      $id = intval($criterion['id'] ?? 0);
+      $description = htmlspecialchars($criterion['description'] ?? '', ENT_QUOTES, 'UTF-8');
+      $status = $criterion['status'] ?? 'pending';
+
+      echo "<tr data-index='" . $index . "'>";
+      echo "<td>";
+      echo "<input type='hidden' name='acceptance_criteria[" . $index . "][id]' value='" . $id . "' />";
+      echo "<textarea name='acceptance_criteria[" . $index . "][description]' rows='2' class='form-control'>" . $description . "</textarea>";
+      echo "</td>";
+      echo "<td>";
+      echo "<select name='acceptance_criteria[" . $index . "][status]' class='form-control'>";
+      foreach (self::getAcceptanceStatusOptions() as $value => $label) {
+         $selected = ($status === $value) ? " selected" : '';
+         echo "<option value='" . $value . "'" . $selected . ">" . htmlspecialchars($label, ENT_QUOTES, 'UTF-8') . "</option>";
+      }
+      echo "</select>";
+      echo "</td>";
+      echo "<td class='text-center'>";
+      echo "<button type='button' class='btn btn-outline-danger btn-sm' onclick='PluginScrumbanCardForm.removeRow(this)'>&times;</button>";
+      echo "</td>";
+      echo "</tr>";
+   }
+
+   private static function renderTestScenarioRow($index, $scenario) {
+      $id = intval($scenario['id'] ?? 0);
+      $name = htmlspecialchars($scenario['name'] ?? '', ENT_QUOTES, 'UTF-8');
+      $status = $scenario['status'] ?? 'not_run';
+      $notes = htmlspecialchars($scenario['notes'] ?? '', ENT_QUOTES, 'UTF-8');
+
+      echo "<tr data-index='" . $index . "'>";
+      echo "<td>";
+      echo "<input type='hidden' name='test_scenarios[" . $index . "][id]' value='" . $id . "' />";
+      echo "<input type='text' name='test_scenarios[" . $index . "][name]' value='" . $name . "' class='form-control' />";
+      echo "</td>";
+      echo "<td>";
+      echo "<select name='test_scenarios[" . $index . "][status]' class='form-control'>";
+      foreach (self::getTestScenarioStatusOptions() as $value => $label) {
+         $selected = ($status === $value) ? " selected" : '';
+         echo "<option value='" . $value . "'" . $selected . ">" . htmlspecialchars($label, ENT_QUOTES, 'UTF-8') . "</option>";
+      }
+      echo "</select>";
+      echo "</td>";
+      echo "<td>";
+      echo "<textarea name='test_scenarios[" . $index . "][notes]' rows='2' class='form-control'>" . $notes . "</textarea>";
+      echo "</td>";
+      echo "<td class='text-center'>";
+      echo "<button type='button' class='btn btn-outline-danger btn-sm' onclick='PluginScrumbanCardForm.removeRow(this)'>&times;</button>";
+      echo "</td>";
+      echo "</tr>";
+   }
+
+   private static function renderCardFormScripts() {
+      $acceptance_options = json_encode(self::getAcceptanceStatusOptions(), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP);
+      $test_options = json_encode(self::getTestScenarioStatusOptions(), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP);
+
+      ob_start();
+      ?>
+<script>
+(function() {
+   if (!window.PluginScrumbanCardForm) {
+      window.PluginScrumbanCardForm = {
+         acceptanceOptions: {},
+         testOptions: {},
+         acceptanceIndex: 0,
+         testIndex: 0,
+         init: function(acceptanceOptions, testOptions) {
+            this.acceptanceOptions = acceptanceOptions || {};
+            this.testOptions = testOptions || {};
+            var acceptanceRows = document.querySelectorAll('#acceptance-criteria-table tbody tr');
+            var scenarioRows = document.querySelectorAll('#test-scenarios-table tbody tr');
+            this.acceptanceIndex = acceptanceRows ? acceptanceRows.length : 0;
+            this.testIndex = scenarioRows ? scenarioRows.length : 0;
+         },
+         removeRow: function(button) {
+            var row = button.closest('tr');
+            if (row && row.parentNode) {
+               row.parentNode.removeChild(row);
+            }
+         },
+         addAcceptanceCriterion: function() {
+            var tbody = document.querySelector('#acceptance-criteria-table tbody');
+            if (!tbody) { return; }
+            var index = this.acceptanceIndex++;
+            var row = document.createElement('tr');
+            row.setAttribute('data-index', index);
+            row.innerHTML = "<td><input type='hidden' name='acceptance_criteria[" + index + "][id]' value='0' />" +
+               "<textarea name='acceptance_criteria[" + index + "][description]' rows='2' class='form-control'></textarea></td>" +
+               "<td>" + this.buildSelect('acceptance_criteria[' + index + '][status]', this.acceptanceOptions, 'pending') + "</td>" +
+               "<td class='text-center'><button type='button' class='btn btn-outline-danger btn-sm' onclick='PluginScrumbanCardForm.removeRow(this)'>&times;</button></td>";
+            tbody.appendChild(row);
+         },
+         addTestScenario: function() {
+            var tbody = document.querySelector('#test-scenarios-table tbody');
+            if (!tbody) { return; }
+            var index = this.testIndex++;
+            var row = document.createElement('tr');
+            row.setAttribute('data-index', index);
+            row.innerHTML = "<td><input type='hidden' name='test_scenarios[" + index + "][id]' value='0' />" +
+               "<input type='text' name='test_scenarios[" + index + "][name]' class='form-control' value='' /></td>" +
+               "<td>" + this.buildSelect('test_scenarios[' + index + '][status]', this.testOptions, 'not_run') + "</td>" +
+               "<td><textarea name='test_scenarios[" + index + "][notes]' rows='2' class='form-control'></textarea></td>" +
+               "<td class='text-center'><button type='button' class='btn btn-outline-danger btn-sm' onclick='PluginScrumbanCardForm.removeRow(this)'>&times;</button></td>";
+            tbody.appendChild(row);
+         },
+         buildSelect: function(name, options, selected) {
+            var html = "<select name='" + name + "' class='form-control'>";
+            for (var value in options) {
+               if (!Object.prototype.hasOwnProperty.call(options, value)) {
+                  continue;
+               }
+               var isSelected = value === selected ? " selected" : "";
+               html += "<option value='" + value + "'" + isSelected + ">" + options[value] + "</option>";
+            }
+            html += "</select>";
+            return html;
+         }
+      };
+   }
+   window.PluginScrumbanCardForm.init(<?php echo $acceptance_options; ?>, <?php echo $test_options; ?>);
+})();
+</script>
+<?php
+      echo ob_get_clean();
+   }
+
+   private function captureCollectionsFromInput(array &$input) {
+      if (array_key_exists('acceptance_criteria', $input)) {
+         $this->pendingAcceptanceCriteria = self::sanitizeAcceptanceCriteriaInput($input['acceptance_criteria']);
+         unset($input['acceptance_criteria']);
+      }
+
+      if (array_key_exists('test_scenarios', $input)) {
+         $this->pendingTestScenarios = self::sanitizeTestScenariosInput($input['test_scenarios']);
+         unset($input['test_scenarios']);
+      }
+   }
+
+   private static function sanitizeAcceptanceCriteriaInput($criteria) {
+      $sanitized = [];
+      if (!is_array($criteria)) {
+         return $sanitized;
+      }
+
+      $position = 0;
+      foreach ($criteria as $criterion) {
+         $description = isset($criterion['description']) ? trim($criterion['description']) : '';
+         $id = isset($criterion['id']) ? intval($criterion['id']) : 0;
+
+         if ($description === '') {
+            continue;
+         }
+
+         $status = isset($criterion['status']) && in_array($criterion['status'], self::ACCEPTANCE_STATUSES, true) ? $criterion['status'] : 'pending';
+
+         $sanitized[] = [
+            'id' => $id,
+            'description' => $description,
+            'status' => $status,
+            'position' => $position++
+         ];
+      }
+
+      return $sanitized;
+   }
+
+   private static function sanitizeTestScenariosInput($scenarios) {
+      $sanitized = [];
+      if (!is_array($scenarios)) {
+         return $sanitized;
+      }
+
+      $position = 0;
+      foreach ($scenarios as $scenario) {
+         $name = isset($scenario['name']) ? trim($scenario['name']) : '';
+         $notes = isset($scenario['notes']) ? trim($scenario['notes']) : '';
+         $id = isset($scenario['id']) ? intval($scenario['id']) : 0;
+
+         if ($name === '' && $notes === '') {
+            continue;
+         }
+
+         $status = isset($scenario['status']) && in_array($scenario['status'], self::TEST_SCENARIO_STATUSES, true) ? $scenario['status'] : 'not_run';
+
+         $sanitized[] = [
+            'id' => $id,
+            'name' => $name,
+            'status' => $status,
+            'notes' => $notes,
+            'position' => $position++
+         ];
+      }
+
+      return $sanitized;
+   }
+
+   static function getAcceptanceCriteriaForCard($card_id) {
+      global $DB;
+
+      if (!$card_id) {
+         return [];
+      }
+
+      $iterator = $DB->request([
+         'FROM' => 'glpi_plugin_scrumban_card_acceptance_criteria',
+         'WHERE' => ['cards_id' => $card_id],
+         'ORDER' => ['position', 'id']
+      ]);
+
+      $criteria = [];
+      foreach ($iterator as $row) {
+         $criteria[] = $row;
+      }
+
+      return $criteria;
+   }
+
+   static function getTestScenariosForCard($card_id) {
+      global $DB;
+
+      if (!$card_id) {
+         return [];
+      }
+
+      $iterator = $DB->request([
+         'FROM' => 'glpi_plugin_scrumban_card_test_scenarios',
+         'WHERE' => ['cards_id' => $card_id],
+         'ORDER' => ['position', 'id']
+      ]);
+
+      $scenarios = [];
+      foreach ($iterator as $row) {
+         $scenarios[] = $row;
+      }
+
+      return $scenarios;
+   }
+
+   private function sanitizeCardInput(array &$input) {
+      foreach (['dor_percent', 'dod_percent'] as $field) {
+         if (isset($input[$field])) {
+            $value = intval($input[$field]);
+            $input[$field] = max(0, min(100, $value));
+         }
+      }
+
+      foreach (['due_date', 'planned_due_date', 'done_date'] as $date_field) {
+         if (isset($input[$date_field]) && $input[$date_field] === '') {
+            $input[$date_field] = null;
+         }
+      }
+
+      foreach (['branch', 'pull_request'] as $text_field) {
+         if (isset($input[$text_field])) {
+            $input[$text_field] = trim($input[$text_field]);
+         }
+      }
+   }
+
+   private function persistAcceptanceCriteria() {
+      global $DB;
+
+      if ($this->pendingAcceptanceCriteria === null) {
+         return;
+      }
+
+      $card_id = $this->getID();
+      if (!$card_id) {
+         return;
+      }
+
+      $existing_ids = [];
+      $result = $DB->request([
+         'SELECT' => 'id',
+         'FROM' => 'glpi_plugin_scrumban_card_acceptance_criteria',
+         'WHERE' => ['cards_id' => $card_id]
+      ]);
+      foreach ($result as $row) {
+         $existing_ids[] = intval($row['id']);
+      }
+
+      $kept_ids = [];
+      foreach ($this->pendingAcceptanceCriteria as $criterion) {
+         $data = [
+            'description' => $criterion['description'],
+            'status' => $criterion['status'],
+            'position' => $criterion['position'],
+            'date_mod' => $_SESSION['glpi_currenttime']
+         ];
+
+         if ($criterion['id'] > 0) {
+            $DB->update('glpi_plugin_scrumban_card_acceptance_criteria', $data, ['id' => $criterion['id']]);
+            $kept_ids[] = $criterion['id'];
+         } else {
+            $data['cards_id'] = $card_id;
+            $data['date_creation'] = $_SESSION['glpi_currenttime'];
+            $DB->insert('glpi_plugin_scrumban_card_acceptance_criteria', $data);
+            $kept_ids[] = $DB->insertId();
+         }
+      }
+
+      $to_delete = array_diff($existing_ids, $kept_ids);
+      if (!empty($to_delete)) {
+         $DB->delete('glpi_plugin_scrumban_card_acceptance_criteria', ['id' => $to_delete]);
+      }
+
+      $this->pendingAcceptanceCriteria = null;
+   }
+
+   private function persistTestScenarios() {
+      global $DB;
+
+      if ($this->pendingTestScenarios === null) {
+         return;
+      }
+
+      $card_id = $this->getID();
+      if (!$card_id) {
+         return;
+      }
+
+      $existing_ids = [];
+      $result = $DB->request([
+         'SELECT' => 'id',
+         'FROM' => 'glpi_plugin_scrumban_card_test_scenarios',
+         'WHERE' => ['cards_id' => $card_id]
+      ]);
+      foreach ($result as $row) {
+         $existing_ids[] = intval($row['id']);
+      }
+
+      $kept_ids = [];
+      foreach ($this->pendingTestScenarios as $scenario) {
+         $data = [
+            'name' => $scenario['name'],
+            'status' => $scenario['status'],
+            'notes' => $scenario['notes'],
+            'position' => $scenario['position'],
+            'date_mod' => $_SESSION['glpi_currenttime']
+         ];
+
+         if ($scenario['id'] > 0) {
+            $DB->update('glpi_plugin_scrumban_card_test_scenarios', $data, ['id' => $scenario['id']]);
+            $kept_ids[] = $scenario['id'];
+         } else {
+            $data['cards_id'] = $card_id;
+            $data['date_creation'] = $_SESSION['glpi_currenttime'];
+            $DB->insert('glpi_plugin_scrumban_card_test_scenarios', $data);
+            $kept_ids[] = $DB->insertId();
+         }
+      }
+
+      $to_delete = array_diff($existing_ids, $kept_ids);
+      if (!empty($to_delete)) {
+         $DB->delete('glpi_plugin_scrumban_card_test_scenarios', ['id' => $to_delete]);
+      }
+
+      $this->pendingTestScenarios = null;
+   }
+
    static function getTypeName($nb = 0) {
       return _n('Card', 'Cards', $nb, 'scrumban');
    }
@@ -93,6 +477,9 @@ class PluginScrumbanCard extends CommonDBTM {
             $sprints[$sprint['id']] = $sprint['name'];
          }
       }
+
+      $acceptance_criteria = $this->getID() ? self::getAcceptanceCriteriaForCard($this->getID()) : [];
+      $test_scenarios = $this->getID() ? self::getTestScenariosForCard($this->getID()) : [];
 
       echo "<tr class='tab_bg_1'>";
       echo "<td>" . __('Board', 'scrumban') . " *</td>";
@@ -187,9 +574,78 @@ class PluginScrumbanCard extends CommonDBTM {
       echo "</tr>";
 
       echo "<tr class='tab_bg_1'>";
+      echo "<td>" . __('Planned Due Date', 'scrumban') . "</td>";
+      echo "<td>";
+      Html::showDateField("planned_due_date", ['value' => $this->fields["planned_due_date"]]);
+      echo "</td>";
+      echo "<td>" . __('Done Date', 'scrumban') . "</td>";
+      echo "<td>";
+      Html::showDateField("done_date", ['value' => $this->fields["done_date"]]);
+      echo "</td>";
+      echo "</tr>";
+
+      echo "<tr class='tab_bg_1'>";
+      echo "<td>" . __('Branch', 'scrumban') . "</td>";
+      echo "<td>";
+      Html::autocompletionTextField($this, "branch", ['size' => 40]);
+      echo "</td>";
+      echo "<td>" . __('Pull Request', 'scrumban') . "</td>";
+      echo "<td>";
+      Html::autocompletionTextField($this, "pull_request", ['size' => 40]);
+      echo "</td>";
+      echo "</tr>";
+
+      echo "<tr class='tab_bg_1'>";
+      echo "<td>" . __('Definition of Ready', 'scrumban') . " (%)</td>";
+      echo "<td>";
+      echo "<input type='number' min='0' max='100' name='dor_percent' value='" . intval($this->fields['dor_percent']) . "' class='form-control' />";
+      echo "</td>";
+      echo "<td>" . __('Definition of Done', 'scrumban') . " (%)</td>";
+      echo "<td>";
+      echo "<input type='number' min='0' max='100' name='dod_percent' value='" . intval($this->fields['dod_percent']) . "' class='form-control' />";
+      echo "</td>";
+      echo "</tr>";
+
+      echo "<tr class='tab_bg_1'>";
       echo "<td>" . __('Description', 'scrumban') . "</td>";
       echo "<td colspan='3'>";
       echo "<textarea name='description' rows='6' cols='80'>" . $this->fields["description"] . "</textarea>";
+      echo "</td>";
+      echo "</tr>";
+
+      echo "<tr class='tab_bg_1'>";
+      echo "<td colspan='4'>";
+      echo "<h3>" . __('Critérios de Aceitação', 'scrumban') . "</h3>";
+      echo "<table class='tab_cadre_fixe' id='acceptance-criteria-table'>";
+      echo "<thead><tr><th>" . __('Descrição', 'scrumban') . "</th><th style='width:180px'>" . __('Status', 'scrumban') . "</th><th style='width:60px'></th></tr></thead>";
+      echo "<tbody>";
+      if (empty($acceptance_criteria)) {
+         $acceptance_criteria[] = ['id' => 0, 'description' => '', 'status' => 'pending'];
+      }
+      foreach ($acceptance_criteria as $index => $criterion) {
+         self::renderAcceptanceCriterionRow($index, $criterion);
+      }
+      echo "</tbody>";
+      echo "</table>";
+      echo "<button type='button' class='btn btn-secondary' onclick='PluginScrumbanCardForm.addAcceptanceCriterion()'>" . __('Adicionar critério', 'scrumban') . "</button>";
+      echo "</td>";
+      echo "</tr>";
+
+      echo "<tr class='tab_bg_1'>";
+      echo "<td colspan='4'>";
+      echo "<h3>" . __('Cenários de Teste', 'scrumban') . "</h3>";
+      echo "<table class='tab_cadre_fixe' id='test-scenarios-table'>";
+      echo "<thead><tr><th>" . __('Cenário', 'scrumban') . "</th><th style='width:180px'>" . __('Status', 'scrumban') . "</th><th>" . __('Notas', 'scrumban') . "</th><th style='width:60px'></th></tr></thead>";
+      echo "<tbody>";
+      if (empty($test_scenarios)) {
+         $test_scenarios[] = ['id' => 0, 'name' => '', 'status' => 'not_run', 'notes' => ''];
+      }
+      foreach ($test_scenarios as $index => $scenario) {
+         self::renderTestScenarioRow($index, $scenario);
+      }
+      echo "</tbody>";
+      echo "</table>";
+      echo "<button type='button' class='btn btn-secondary' onclick='PluginScrumbanCardForm.addTestScenario()'>" . __('Adicionar cenário', 'scrumban') . "</button>";
       echo "</td>";
       echo "</tr>";
 
@@ -205,6 +661,7 @@ class PluginScrumbanCard extends CommonDBTM {
       echo "</tr>";
 
       $this->showFormButtons($options);
+      self::renderCardFormScripts();
       return true;
    }
 
@@ -216,6 +673,9 @@ class PluginScrumbanCard extends CommonDBTM {
          Session::addMessageAfterRedirect(__('You do not have permission to create cards on this board', 'scrumban'), false, ERROR);
          return false;
       }
+
+      $this->captureCollectionsFromInput($input);
+      $this->sanitizeCardInput($input);
 
       // Set position if not provided
       if (!isset($input['position']) && isset($input['columns_id'])) {
@@ -243,8 +703,20 @@ class PluginScrumbanCard extends CommonDBTM {
          }
       }
 
+      $this->captureCollectionsFromInput($input);
+      $this->sanitizeCardInput($input);
       $input['date_mod'] = $_SESSION['glpi_currenttime'];
       return $input;
+   }
+
+   function post_addItem() {
+      $this->persistAcceptanceCriteria();
+      $this->persistTestScenarios();
+   }
+
+   function post_updateItem($history = 1) {
+      $this->persistAcceptanceCriteria();
+      $this->persistTestScenarios();
    }
 
    /**


### PR DESCRIPTION
## Summary
- add migration and schema changes for extra card fields plus acceptance criteria and test scenario tables
- extend card model and form to manage branch, DoR/DoD metrics, acceptance criteria, and test scenarios
- refresh AJAX card detail rendering to surface new development, acceptance, and QA sections

## Testing
- php -l hook.php
- php -l inc/card.class.php
- php -l ajax/card.php
- php -l front/card.form.php

------
https://chatgpt.com/codex/tasks/task_e_68d69559bef88324a09c4208c4fa5b8d